### PR TITLE
fix(STIGG-3559): dlq tools are missing monitor of dedicated queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.idea/
+.vscode/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,9 +14,8 @@ filters:
       - dlq
   - name: substringBlockList
     values:
-      - developer # no dev queues should be returned :)
-      - webflow
-      - miro
+      - persistent-cache-webflow
+      - persistent-cache-miro
   - name: slackChannelId
     values:
       - name: staging


### PR DESCRIPTION
Make sure we don't exclude dedicated queues like:
```
production-sqs-integrations-dedicated-webflow-production-dlq.fifo
```